### PR TITLE
Add support for multiple data sources

### DIFF
--- a/COVID19Py/covid19.py
+++ b/COVID19Py/covid19.py
@@ -7,12 +7,13 @@ class COVID19(object):
     data_source = ""
     previousData = None
     latestData = None
-    _valid_data_sources = ['jhu', 'csbs']
+    _valid_data_sources = []
 
     def __init__(self, url="https://coronavirus-tracker-api.herokuapp.com", data_source='jhu'):
+        self.url = url
+        self._valid_data_sources = self._getSources()
         if data_source not in self._valid_data_sources:
             raise ValueError("Invalid data source. Expected one of: %s" % self._valid_data_sources)
-        self.url = url
         self.data_source = data_source
 
     def _update(self, timelines):
@@ -24,6 +25,11 @@ class COVID19(object):
             "latest": latest,
             "locations": locations
         }
+
+    def _getSources(self):
+        response = requests.get(self.url + "/v2/sources")
+        response.raise_for_status()
+        return response.json()["sources"]
 
     def _request(self, endpoint, params=None):
         if params is None:

--- a/COVID19Py/covid19.py
+++ b/COVID19Py/covid19.py
@@ -4,11 +4,16 @@ import requests
 
 class COVID19(object):
     url = ""
+    data_source = ""
     previousData = None
     latestData = None
+    _valid_data_sources = ['jhu', 'csbs']
 
-    def __init__(self, url="https://coronavirus-tracker-api.herokuapp.com"):
+    def __init__(self, url="https://coronavirus-tracker-api.herokuapp.com", data_source='jhu'):
+        if data_source not in self._valid_data_sources:
+            raise ValueError("Invalid data source. Expected one of: %s" % self._valid_data_sources)
         self.url = url
+        self.data_source = data_source
 
     def _update(self, timelines):
         latest = self.getLatest()
@@ -21,7 +26,9 @@ class COVID19(object):
         }
 
     def _request(self, endpoint, params=None):
-        response = requests.get(self.url + endpoint, params)
+        if params is None:
+            params = {}
+        response = requests.get(self.url + endpoint, {**params, "source":self.data_source})
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
As mentioned in #7, ExpDev07/coronavirus-tracker-api recently added multiple data sources.

This implements those changes into the library by adding the option to choose the data source to use.

The default data source is `jsu`.