### PR TITLE
Specify encoding of README.md file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Not everyone has their system setup with 'utf-8' default encoding, so open might fail, see:

https://stackoverflow.com/questions/62685606/when-i-use-jupyter-notebook-to-pip-install-covid19py-i-get-a-error-command-erro#62685606

Feel free to close this and re-do the change yourself, I don't particularly care to be listed as a contributor for such a trivial change.