### PR TITLE
Change backend

### DIFF
--- a/COVID19Py/covid19.py
+++ b/COVID19Py/covid19.py
@@ -9,7 +9,7 @@ class COVID19(object):
     latestData = None
     _valid_data_sources = []
 
-    def __init__(self, url="https://coronavirus-tracker-api.herokuapp.com", data_source='jhu'):
+    def __init__(self, url="https://covid-tracker-us.herokuapp.com", data_source='jhu'):
         self.url = url
         self._valid_data_sources = self._getSources()
         if data_source not in self._valid_data_sources:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A tiny Python package for easy access to up-to-date Coronavirus (COVID-19, SARS-
 
 ## About
 
-COVID19Py is a Python wrapper for the [ExpDev07/coronavirus-tracker-api](https://github.com/ExpDev07/coronavirus-tracker-api) REST API.
-It retrieves data directly from [@ExpDev07](https://github.com/ExpDev07)'s backend but it can also be set up to use a different backend.
+COVID19Py is a Python wrapper made to be compatible with [ExpDev07/coronavirus-tracker-api](https://github.com/ExpDev07/coronavirus-tracker-api) REST API.
+It retrieves data directly from an instance of [@ExpDev07](https://covid-tracker-us.herokuapp.com/)'s backend but it can also be set up to use a different backend.
 
 To achieve this, just pass the URL of the backend as a parameter to the library's constructor:
 ```python


### PR DESCRIPTION
Migrate to new instance of the backend server:
https://covid-tracker-us.herokuapp.com

Although I'm not entirely sure if this new backend is completely compatible with our API, it does appear to be a fork of ExpDev07's project, and passes the sniff test.

If we do want this new data source, this PR has the changes needed to migrate that way. I changed the default URL in the constructor, as well as changed a bit of docs to show we are pulling from a different backend.

If everything here seems ok, feel free to merge it in.