### PR TITLE
Add file with available API mirrors

### DIFF
--- a/mirrors.json
+++ b/mirrors.json
@@ -1,0 +1,14 @@
+[
+    {
+        "url": "https://covid-tracker-us.herokuapp.com/",
+        "provider": ""
+    },
+    {
+        "url": "https://cvtapi.nl",
+        "provider": "https://github.com/Toxyl"
+    },
+    {
+        "url": "http://covid19-api.kamaropoulos.com/",
+        "provider": "https://github.com/Kamaropoulos"
+    }
+]


### PR DESCRIPTION
Not the most elegant solution for now but we need a way to know what are the available mirrors of the API. This way we can try and hit another mirror if one is now functioning properly.