### PR TITLE
Add ApiData aggregate

### DIFF
--- a/COVID19Py/covid19.py
+++ b/COVID19Py/covid19.py
@@ -2,24 +2,127 @@ from typing import Dict, List
 import requests
 import json
 
-class COVID19(object):
+class COVID19:
+    latestData = None
+    previousData = None
+
+    def __init__(self):
+        self.apiData = ApiData()
+
+    def _update(self, timelines):
+        latest = self.getLatest()
+        locations = self.getLocations(timelines)
+        if self.latestData:
+            self.previousData = self.latestData
+        self.latestData = {
+            "latest": latest,
+            "locations": locations
+        }
+
+    def getAll(self, timelines=False):
+        self._update(timelines)
+        return self.latestData
+
+    def getLatestChanges(self):
+        changes = None
+        if self.previousData:
+            changes = {
+                "confirmed": self.latestData["latest"]["confirmed"] - self.latestData["latest"]["confirmed"],
+                "deaths": self.latestData["latest"]["deaths"] - self.latestData["latest"]["deaths"],
+                "recovered": self.latestData["latest"]["recovered"] - self.latestData["latest"]["recovered"],
+            }
+        else:
+            changes = {
+                "confirmed": 0,
+                "deaths": 0,
+                "recovered": 0,
+            }
+        return changes
+
+    def getLatest(self) -> List[Dict[str, int]]:
+        """
+        :return: The latest amount of total confirmed cases, deaths, and recoveries.
+        """
+        data = self.apiData.request("/v2/latest")
+        return data["latest"]
+
+    def getLocations(self, timelines=False, rank_by: str = None) -> List[Dict]:
+        """
+        Gets all locations affected by COVID-19, as well as latest case data.
+        :param timelines: Whether timeline information should be returned as well.
+        :param rank_by: Category to rank results by. ex: confirmed
+        :return: List of dictionaries representing all affected locations.
+        """
+        data = None
+        if timelines:
+            data = self.apiData.request("/v2/locations", {"timelines": str(timelines).lower()})
+        else:
+            data = self.apiData.request("/v2/locations")
+
+        data = data["locations"]
+        
+        ranking_criteria = ['confirmed', 'deaths', 'recovered']
+        if rank_by is not None:
+            if rank_by not in ranking_criteria:
+                raise ValueError("Invalid ranking criteria. Expected one of: %s" % ranking_criteria)
+
+            ranked = sorted(data, key=lambda i: i['latest'][rank_by], reverse=True)
+            data = ranked
+
+        return data
+
+    def getLocationByCountryCode(self, country_code, timelines=False) -> List[Dict]:
+        """
+        :param country_code: String denoting the ISO 3166-1 alpha-2 code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) of the country
+        :param timelines: Whether timeline information should be returned as well.
+        :return: A list of areas that correspond to the country_code. If the country_code is invalid, it returns an empty list.
+        """
+        data = None
+        if timelines:
+            data = self.apiData.request("/v2/locations", {"country_code": country_code, "timelines": str(timelines).lower()})
+        else:
+            data = self.apiData.request("/v2/locations", {"country_code": country_code})
+        return data["locations"]
+    
+    def getLocationByCountry(self, country, timelines=False) -> List[Dict]:
+        """
+        :param country: String denoting name of the country
+        :param timelines: Whether timeline information should be returned as well.
+        :return: A list of areas that correspond to the country name. If the country is invalid, it returns an empty list.
+        """
+        data = None
+        if timelines:
+            data = self.apiData.request("/v2/locations", {"country": country, "timelines": str(timelines).lower()})
+        else:
+            data = self.apiData.request("/v2/locations", {"country": country})
+        return data["locations"]
+
+    def getLocationById(self, country_id: int):
+        """
+        :param country_id: Country Id, an int
+        :return: A dictionary with case information for the specified location.
+        """
+        data = self.apiData.request("/v2/locations/" + str(country_id))
+        return data["location"]
+class ApiData:
+
     default_url = "https://covid-tracker-us.herokuapp.com"
     url = ""
     data_source = ""
-    previousData = None
-    latestData = None
     _valid_data_sources = []
 
     mirrors_source = "https://raw.github.com/Kamaropoulos/COVID19Py/master/mirrors.json"
     mirrors = None
 
-    def __init__(self, url="https://covid-tracker-us.herokuapp.com", data_source='jhu'):
+    def __init__(self, url="https://covid-tracker-us.herokuapp.com", data_source='csbs'):
         # Skip mirror checking if custom url was passed
+        
         if url == self.default_url:
             # Load mirrors
             response = requests.get(self.mirrors_source)
             response.raise_for_status()
             self.mirrors = response.json()
+            
 
             # Try to get sources as a test
             for mirror in self.mirrors:
@@ -49,110 +152,15 @@ class COVID19(object):
             raise ValueError("Invalid data source. Expected one of: %s" % self._valid_data_sources)
         self.data_source = data_source
 
-    def _update(self, timelines):
-        latest = self.getLatest()
-        locations = self.getLocations(timelines)
-        if self.latestData:
-            self.previousData = self.latestData
-        self.latestData = {
-            "latest": latest,
-            "locations": locations
-        }
 
     def _getSources(self):
         response = requests.get(self.url + "/v2/sources")
         response.raise_for_status()
         return response.json()["sources"]
 
-    def _request(self, endpoint, params=None):
+    def request(self, endpoint, params=None):
         if params is None:
             params = {}
         response = requests.get(self.url + endpoint, {**params, "source":self.data_source})
         response.raise_for_status()
         return response.json()
-
-    def getAll(self, timelines=False):
-        self._update(timelines)
-        return self.latestData
-
-    def getLatestChanges(self):
-        changes = None
-        if self.previousData:
-            changes = {
-                "confirmed": self.latestData["latest"]["confirmed"] - self.latestData["latest"]["confirmed"],
-                "deaths": self.latestData["latest"]["deaths"] - self.latestData["latest"]["deaths"],
-                "recovered": self.latestData["latest"]["recovered"] - self.latestData["latest"]["recovered"],
-            }
-        else:
-            changes = {
-                "confirmed": 0,
-                "deaths": 0,
-                "recovered": 0,
-            }
-        return changes
-
-    def getLatest(self) -> List[Dict[str, int]]:
-        """
-        :return: The latest amount of total confirmed cases, deaths, and recoveries.
-        """
-        data = self._request("/v2/latest")
-        return data["latest"]
-
-    def getLocations(self, timelines=False, rank_by: str = None) -> List[Dict]:
-        """
-        Gets all locations affected by COVID-19, as well as latest case data.
-        :param timelines: Whether timeline information should be returned as well.
-        :param rank_by: Category to rank results by. ex: confirmed
-        :return: List of dictionaries representing all affected locations.
-        """
-        data = None
-        if timelines:
-            data = self._request("/v2/locations", {"timelines": str(timelines).lower()})
-        else:
-            data = self._request("/v2/locations")
-
-        data = data["locations"]
-        
-        ranking_criteria = ['confirmed', 'deaths', 'recovered']
-        if rank_by is not None:
-            if rank_by not in ranking_criteria:
-                raise ValueError("Invalid ranking criteria. Expected one of: %s" % ranking_criteria)
-
-            ranked = sorted(data, key=lambda i: i['latest'][rank_by], reverse=True)
-            data = ranked
-
-        return data
-
-    def getLocationByCountryCode(self, country_code, timelines=False) -> List[Dict]:
-        """
-        :param country_code: String denoting the ISO 3166-1 alpha-2 code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) of the country
-        :param timelines: Whether timeline information should be returned as well.
-        :return: A list of areas that correspond to the country_code. If the country_code is invalid, it returns an empty list.
-        """
-        data = None
-        if timelines:
-            data = self._request("/v2/locations", {"country_code": country_code, "timelines": str(timelines).lower()})
-        else:
-            data = self._request("/v2/locations", {"country_code": country_code})
-        return data["locations"]
-    
-    def getLocationByCountry(self, country, timelines=False) -> List[Dict]:
-        """
-        :param country: String denoting name of the country
-        :param timelines: Whether timeline information should be returned as well.
-        :return: A list of areas that correspond to the country name. If the country is invalid, it returns an empty list.
-        """
-        data = None
-        if timelines:
-            data = self._request("/v2/locations", {"country": country, "timelines": str(timelines).lower()})
-        else:
-            data = self._request("/v2/locations", {"country": country})
-        return data["locations"]
-
-    def getLocationById(self, country_id: int):
-        """
-        :param country_id: Country Id, an int
-        :return: A dictionary with case information for the specified location.
-        """
-        data = self._request("/v2/locations/" + str(country_id))
-        return data["location"]


### PR DESCRIPTION
### What does it Do
Since this repository is a wrapper of another API, the `COVID19` class acts as an encapsulation of the API. So I decided to create a `COVID19` aggregate. The `COVID19` class acts as the root aggregate and only the functions inside this class will be accessible by the package users. The root aggregate will ensure that the integrity of the whole model is maintained. The other class is the `ApiData`, this class contains all the private functions related to fetching the data from the API that used to exist in the `COVID19` class. It has been moved to `ApiData` class to better ensure that the domain driven design patterns are followed.  So if you zoom out, the COVID19 aggregate contains a class called ApiData which fetches all the data.

### How does it Do it?
- Moves `request` and `_getSources` into a separate class called `ApiData`

### Why?

- Improved performance 
- Better code readability
- Follows Domain Driven Design Patterns
- Makes the datasource explicit
