### PR TITLE
Request information on a list of countries through the bridge pattern

### DIFF
--- a/COVID19Py/covid19.py
+++ b/COVID19Py/covid19.py
@@ -236,5 +236,3 @@ class COUNTRIES(object):
         for i in country_list:
             self.country_list.append(self.covid_obj.getLocationById(i))
         return self.country_list
-
-    

--- a/COVID19Py/covid19.py
+++ b/COVID19Py/covid19.py
@@ -160,7 +160,7 @@ class COVID19(object):
         data = self._request("/v2/locations/" + str(country_id))
         return data["location"]
     
-    def getMultipleCountries(self, name: str, type = 0, countries = [], time_line = False):
+    def getMultipleCountries(self, name: str, typeCall = 0, countries = [], time_line = False):
         """
         :param name: A unique (within dictionary user_lists) identifying name for a list of countries
             If name is not unique, the old list of countries will be replaced with parameter countries[] or use 
@@ -181,21 +181,21 @@ class COVID19(object):
         check = self.user_lists.get(name)
         #If the passed name is not present in dictionary create new entry
         #else use existing entry
-        if check == None:
+        if check is None:
             self.user_lists.update({name: COUNTRIES(self)})
             data = []
-            if type == 0:
+            if typeCall == 0:
                 data = self.user_lists.get(name)._getCountriesByCode(time_line, countries)
-            elif type == 1:
+            elif typeCall == 1:
                 data = self.user_lists.get(name)._getCountriesByName(time_line, countries)
-            elif type == 2:
+            elif typeCall == 2:
                 data = self.user_lists.get(name)._getCountriesById(countries)
         else:
-            if check.type == 0:
+            if check.typeCall == 0:
                 data = self.user_lists.get(name)._getCountriesByCode(time_line, countries)
-            elif check.type == 1:
+            elif check.typeCall == 1:
                 data = self.user_lists.get(name)._getCountriesByName(time_line, countries)
-            elif check.type == 2:
+            elif check.typeCall == 2:
                 data = self.user_lists.get(name)._getCountriesById(countries)
  
         return data
@@ -205,7 +205,7 @@ class COUNTRIES(object):
     
     covid_obj = None
     country_list = []
-    type = 0
+    typeCall = 0
     
     def __init__(self, covid19_obj):
         self.covid_obj = covid19_obj
@@ -214,7 +214,7 @@ class COUNTRIES(object):
     #and use the newly passed parameter country_list unless the list is empty or not present
     #in this case use the original country_list. Applies to all get methods.
     def _getCountriesByCode(self, timelines = False, country_list = []):
-        self.type = 0
+        self.typeCall = 0
         if country_list != []:
             self.country_list.clear()
         for code in country_list:
@@ -222,7 +222,7 @@ class COUNTRIES(object):
         return self.country_list
     
     def _getCountriesByName(self, timelines = False, country_list = []):
-        self.type = 1
+        self.typeCall = 1
         if country_list != []:
             self.country_list.clear()
         for name in country_list:
@@ -230,12 +230,11 @@ class COUNTRIES(object):
         return self.country_list
     
     def _getCountriesById(self, country_list = []):
-        self.type = 2
+        self.typeCall = 2
         if country_list != []:
             self.country_list.clear()
-        for id in country_list:
-            self.country_list.append(self.covid_obj.getLocationById(id))
+        for i in country_list:
+            self.country_list.append(self.covid_obj.getLocationById(i))
         return self.country_list
-
 
     

--- a/COVID19Py/covidInterfaces.py
+++ b/COVID19Py/covidInterfaces.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+
+class I_SOURCE(object):
+    """
+    An interface to implement new instances of COVID19 to use within a single instance of COVID19.
+    These instances can pull data from alternate sources or different back ends.
+    """
+    
+    def __init__(self, url, data_source):
+        """Create a new covid19 instance with the desired data source"""
+        pass
+    
+    def accessAlt(self):
+        """Return alternate source"""
+        pass
+
+
+class ABSTRACT_COUNTRIES(ABC):
+    """
+    An abstract class that holds a list of multiple countries. COVID19 information from each country
+    can be accessed at once.
+    """
+    
+    @abstractmethod
+    def _getCountriesByCode(self, timelines = False, country_list = []):
+        """Return a list of countries when given their codes"""
+        pass
+    
+    @abstractmethod
+    def _getCountriesByName(self, timelines = False, country_list = []):
+        """Return a list of countries when given their names"""
+        pass
+    
+    @abstractmethod
+    def _getCountriesById(self, country_list = []):
+        """Return a list of countries when given their ids"""
+        pass


### PR DESCRIPTION
What I added was two classes `COUNTRIES` and `ALT_SOURCE`. `COUNTRIES` stores a list of countries which can have their covid19 data requested all at once. `ALT_SOURCE` stores an instance of `COVID19` where you can provide a different url and data_source for information. The goal with connecting these two classes by the bridge pattern is so you can have any combination of countries, requesting data through any data_source. This should help if a user wants to switch data sources if response times are low or not working on one data source. Being able to request information from a list of countries is also a convenience. A dictionary of entities called `_country_lists` stores instances of `COUNTRIES` identified by a string `name`. `createCountryList` allows for the creation of a new country list, and `getMultipleCountries` returns the data for a list of countries from an existing `COUNTRIES` entitiy in `_country_lists`.  Please note as stated in my pull request cfd86a5, where I applied the singleton pattern this pull request is not compatible as it creates multiple instance of COVID19.