### PR TITLE
Applied Observer Pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/
+.pytest_cache/

--- a/COVID19Py/publisher.py
+++ b/COVID19Py/publisher.py
@@ -1,0 +1,64 @@
+class GenericPublisher:
+    """
+    This class represents a generic publisher with add, remove and notify functions
+    """
+
+    def __init__(self):
+        self.observerList = []
+
+    def addNewObserver(self, observer):
+        """
+        This methods adds a new observer `observer` to the list of observers
+
+        :param observer: observer to add to the list
+        :return:None
+        """
+        if observer not in self.observerList:
+            self.observerList.append(observer)
+        else:
+            # Already in this list, pass
+            pass
+
+    def removeObserver(self, observer):
+        """
+        This method removes an observer from the list of observers
+
+        :param observer: Observer to remove
+        :return: None
+        """
+        try:
+            self.observerList.remove(observer)
+        except Exception:
+            raise Exception("observer not in the list")
+
+    def notifyObservers(self):
+        """
+        This method notifies all the observers in the list of observers about a change to the publisher.
+        :return: None
+        """
+        [currObserver.notifyObservers(self) for currObserver in self.observerList]
+
+
+class LatestDataPublisher(GenericPublisher):
+    """
+    This class represents `latestData` publisher
+    """
+
+    def __init__(self):
+        GenericPublisher.__init__(self)
+        self.latestData = None
+        self.latestDataCopy = None
+
+    def set_latestData(self, newData):
+        """
+        This setter function sets the value of `latestData` to `newData`
+        :param newData: new value to set `latestData` to.
+        :return: None
+        """
+        try:
+            self.latestDataCopy = self.latestData
+            self.latestData = newData
+        except Exception:
+            raise Exception("Error setting latestData's value")
+        else:
+            self.notifyObservers()

--- a/COVID19Py/subscriber.py
+++ b/COVID19Py/subscriber.py
@@ -1,0 +1,17 @@
+class PreviousDataSubscriber:
+    """
+    This class represents the `previousData` observer
+    """
+
+    def __init__(self):
+        self.previousData = None
+
+    def notifyObservers(self, publisher):
+        """
+        This method is called from the publisher when a possible update to the subject happens.
+        It updates the `previousData` after the publisher (latestData) is updated.
+
+        :param publisher: publisher object for which this observer object monitors
+        :return: None
+        """
+        self.previousData = publisher.latestDataCopy

--- a/COVID19Py/test_observer_pattern.py
+++ b/COVID19Py/test_observer_pattern.py
@@ -1,0 +1,17 @@
+import pytest
+from COVID19Py import COVID19
+
+
+@pytest.fixture
+def covid_obj():
+    covid19 = COVID19()
+    return covid19
+
+
+def test_publisher_and_subscriber(covid_obj):
+    save_curr_latestData = covid_obj.getAll()
+    # After first invocation of getAll(), previousData should still be None
+    assert covid_obj.previousDataObserver.previousData is None
+    covid_obj.getAll()
+    # After second invocation of getAll(), previousData should be equal to old latestData
+    assert covid_obj.previousDataObserver.previousData is save_curr_latestData

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-requests~=2.24.0
+requests~=2.25.1
+
+setuptools~=49.2.1
+typing~=3.7.4.3
+pytest~=6.2.2


### PR DESCRIPTION
## Applied The Observer Pattern 
I implemented The Observer Design Pattern to the project's `_update()` method. 

## Why is this important?
As of now, the project is quite small and does not offer many extras features. However, If the project were to be extended, the observer pattern makes possible several features. An observer pattern primarily is a "reactor"; when some objects change, other objects monitoring that object can react to the change in some ways.

## How
In the original project, `previousData` would be updated to the old value of `latestData` everytime new data for `latestData` was fetched. This is where observer pattern comes into play. Setting `latestData` as the publisher and `previousData` as a subscriber, everytime `latestData` is changed, `previousData` is updated correspondingly. 

To achieve this **publisher-subscriber** relationship, I created a new class `GenericPublisher` in `publisher.py`; this class represents a general class. Second, created another class `LatestDataPublisher` that extends the `GenericPublisher` class. `LatestDataPublisher` holds the `latestData`. Third, I created a new class `PreviousDataSubscriber`, which represents the `previousData` we previously had. Now, i set up the publisher-subscriber relationship in the `COVID19` class, creating references to **LatestDataPublisher** (`latestDataPublisher`)  and **PreviousDataSubscriber** (`previousDataObserver`) in the constructor. Finally, whenever `_update()` is called, to update the what was previously `latestData` (now `latestDataPublisher.latestData`), `set_latestData()` method is called with the value to update it with and `notifyObservers()` is called to update `previousDataObserver.previousData` .

## Test
To ensure the changes work correctly, I created a test file `test_observer_pattern.py`. The tests were written using `pytest`, as such `requirements.txt` has been updated.

## Is there any existing behaviour change due to this modification?
No, everything works the way it was.
